### PR TITLE
krs #30 - Fixed Sonarcloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,5 @@ before_script:
 script:
 - mvn clean install
 after_success:
-- mvn -P coverage
+- mvn -P coverage-sonar
+- mvn -P coverage-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ before_script:
 script:
 - mvn clean install
 after_success:
-- mvn cobertura:cobertura-integration-test coveralls:report sonar:sonar
+- mvn -P coverage

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Master:  
 [![Master Build Status](https://travis-ci.org/andrewflbarnes/kings-results-service.svg?branch=master)](https://travis-ci.org/andrewflbarnes/kings-results-service) 
-[![Coverage Status](https://coveralls.io/repos/github/andrewflbarnes/kings-results-service/badge.svg?branch=master)](https://coveralls.io/github/andrewflbarnes/kings-results-service?branch=master)
-[![Quality Gate](https://sonarcloud.io/api/badges/gate?key=org.kingsski:kings-race-service)](https://sonarcloud.io/dashboard?id=org.kingsski:kings-race-service)
+[![Coverage Status](https://img.shields.io/coveralls/github/andrewflbarnes/kings-results-service.svg)](https://coveralls.io/github/andrewflbarnes/kings-results-service?branch=master)
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=org.kingsski%3Akings-race-service&metric=alert_status)](https://sonarcloud.io/dashboard?id=org.kingsski:kings-race-service)
 
 Modules:
 - data (lib): contains entity models

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
         <junit.version>4.12</junit.version>
         <mockito.version>2.19.1</mockito.version>
         <failsafe.version>2.22.0</failsafe.version>
+        <jacoco.version>0.7.7.201606060606</jacoco.version>
+        <cobertura.version>2.7</cobertura.version>
     </properties>
 
     <packaging>pom</packaging>
@@ -42,6 +44,78 @@
             <properties>
                 <skipIntegrationTests>true</skipIntegrationTests>
             </properties>
+        </profile>
+        <profile>
+            <id>coverage</id>
+            <activation>
+                <property>
+                    <name>coverage</name>
+                </property>
+            </activation>
+            <build>
+                <defaultGoal>cobertura:cobertura-integration-test coveralls:report sonar:sonar</defaultGoal>
+                <plugins>
+                    <!-- jacoco for sonar -->
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.version}</version>
+                        <configuration>
+                            <append>true</append>
+                            <destFile>${project.build.directory}/jacoco.exec</destFile>
+                            <excludes>
+                                <exclude>**/*Config.class</exclude>
+                                <exclude>**/*Application.class</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>prepare-jacoco</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- cobertura for coveralls -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>cobertura-maven-plugin</artifactId>
+                        <version>${cobertura.version}</version>
+                        <configuration>
+                            <instrumentation>
+                                <ignoreTrivial>true</ignoreTrivial>
+                                <excludes>
+                                    <exclude>**/*Config.class</exclude>
+                                    <exclude>**/*Application.class</exclude>
+                                </excludes>
+                            </instrumentation>
+                            <formats>
+                                <format>html</format>
+                                <format>xml</format>
+                            </formats>
+                            <check />
+                            <maxmem>256m</maxmem>
+                            <!-- aggregated reports for multi-module projects -->
+                            <aggregate>true</aggregate>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.eluder.coveralls</groupId>
+                        <artifactId>coveralls-maven-plugin</artifactId>
+                        <version>4.3.0</version>
+                        <executions>
+                            <execution>
+                                <id>coveralls-coverage</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 
@@ -62,33 +136,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <instrumentation>
-                        <ignoreTrivial>true</ignoreTrivial>
-                        <excludes>
-                            <exclude>**/*Config.class</exclude>
-                            <exclude>**/*Application.class</exclude>
-                        </excludes>
-                    </instrumentation>
-                    <formats>
-                        <format>html</format>
-                        <format>xml</format>
-                    </formats>
-                    <check />
-                    <maxmem>256m</maxmem>
-                    <!-- aggregated reports for multi-module projects -->
-                    <aggregate>true</aggregate>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.eluder.coveralls</groupId>
-                <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -17,18 +17,22 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <!-- project -->
+        <!-- custom property defaults -->
+        <skipIntegrationTests>false</skipIntegrationTests>
+        <!-- project dependencies -->
         <spring.boot.version>2.0.3.RELEASE</spring.boot.version>
         <spring.data.version>2.0.8.RELEASE</spring.data.version>
         <spring.version>5.0.7.RELEASE</spring.version>
         <hsqldb.version>2.4.0</hsqldb.version>
         <jayway.version>2.2.0</jayway.version>
-        <!-- test -->
+        <!-- test dependencies -->
         <junit.version>4.12</junit.version>
         <mockito.version>2.19.1</mockito.version>
         <failsafe.version>2.22.0</failsafe.version>
+        <!-- coverage and code analysis -->
         <jacoco.version>0.7.7.201606060606</jacoco.version>
         <cobertura.version>2.7</cobertura.version>
+        <coveralls.version>4.3.0</coveralls.version>
     </properties>
 
     <packaging>pom</packaging>
@@ -45,15 +49,11 @@
                 <skipIntegrationTests>true</skipIntegrationTests>
             </properties>
         </profile>
+
         <profile>
-            <id>coverage</id>
-            <activation>
-                <property>
-                    <name>coverage</name>
-                </property>
-            </activation>
+            <id>coverage-sonar</id>
             <build>
-                <defaultGoal>cobertura:cobertura-integration-test coveralls:report sonar:sonar</defaultGoal>
+                <defaultGoal>clean install sonar:sonar</defaultGoal>
                 <plugins>
                     <!-- jacoco for sonar -->
                     <plugin>
@@ -71,13 +71,29 @@
                         <executions>
                             <execution>
                                 <id>prepare-jacoco</id>
+                                <phase>initialize</phase>
                                 <goals>
                                     <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>prepare-jacoco-integration</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
                                     <goal>prepare-agent-integration</goal>
                                 </goals>
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>coverage-coveralls</id>
+            <build>
+                <defaultGoal>cobertura:cobertura-integration-test coveralls:report</defaultGoal>
+                <plugins>
                     <!-- cobertura for coveralls -->
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
@@ -104,15 +120,7 @@
                     <plugin>
                         <groupId>org.eluder.coveralls</groupId>
                         <artifactId>coveralls-maven-plugin</artifactId>
-                        <version>4.3.0</version>
-                        <executions>
-                            <execution>
-                                <id>coveralls-coverage</id>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                            </execution>
-                        </executions>
+                        <version>${coveralls.version}</version>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Addresses #30 
Corrected badges and added Jacoco back for the coverage reports - whoops!
Also organised the pom so that profiles are used for each of the coveralls and sonar tasks and plugins are only used in each of these cases